### PR TITLE
WSU Button style updated for new Outlook 365 interface

### DIFF
--- a/plugins/buttonwayne/dialogs/button.js
+++ b/plugins/buttonwayne/dialogs/button.js
@@ -43,7 +43,7 @@
                       <table border="0" cellpadding="0" cellspacing="0">
                         <tbody>
                           <tr>
-                            <td bgcolor="#fdd891" style="border-radius:5px;">
+                            <td bgcolor="#fdd891" style="border-radius:5px;background-color:#fdd891">
                               <a
                                 href="${url}"
                                 style="border-radius:5px; border:1px solid #fdd891; color:#0c5449; display:inline-block; font-family:Helvetica,Arial,sans-serif; font-size:16px; font-weight:bold; padding:12px 18px; text-decoration:none"
@@ -71,7 +71,7 @@
                       <table align="center" border="0" cellpadding="0" cellspacing="0">
                         <tbody>
                           <tr>
-                            <td bgcolor="#fdd891" style="border-radius:5px">
+                            <td bgcolor="#fdd891" style="border-radius:5px;background-color:#fdd891">
                               <a
                                 href="${url}"
                                 style="border-radius:5px; border:1px solid #fdd891; color:#0c5449; display:inline-block; font-family:Helvetica,Arial,sans-serif; font-size:16px; padding:12px 18px; font-weight:bold; text-decoration:none"


### PR DESCRIPTION
## Reason for change

Outlook.com has rolled out a "New Outlook" toggle that changes a bit about how emails area rendered and sent.

Because of that the current "WSU Button" style background is missing in the new interface.

This change restores the background color in the new interface while also keeping it in the old.

## Comparison

| Before | After |
|--------|--------|
| ![72478_143202](https://user-images.githubusercontent.com/37359/53129282-2ca41380-3535-11e9-80af-d4ac035a6a01.png) | ![72478_152148](https://user-images.githubusercontent.com/37359/53129290-30379a80-3535-11e9-8535-6a2734985bbf.png) |
