### PR TITLE
only allow specific link targets in the options

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,6 +24,18 @@ CKEDITOR.editorConfig = function( config ) {
         'script(*)[*];' // Allow script tags to be inserted
     ;
 
+    // Only allow specific link targets
+    CKEDITOR.on('dialogDefinition', function(evt) {
+        var dialogName = evt.data.name;
+        if (dialogName == 'link') {
+            var dialogDefinition = evt.data.definition;
+            var informationTab = dialogDefinition.getContents('target');
+            var targetField = informationTab.get('linkTargetType');
+
+            targetField.items = targetField.items.filter(target => ['_blank', '_self', '_top', '_parent', 'notSet'].includes(target[1]));
+        }
+    });
+
     // Remove allowed margins when pasting from Word
     this.on('afterPasteFromWord', function(evt){
         var filter = evt.editor.filter.clone(),


### PR DESCRIPTION
Removes the popup and the frame options from the link target dropdown