### PR TITLE
fix-figure-padding

### DIFF
--- a/config.js
+++ b/config.js
@@ -107,7 +107,7 @@ CKEDITOR.editorConfig = function( config ) {
                 {
                     element: 'img',
                     left: function(el) {
-                        return el.parent && el.parent.classes.indexOf('figure');
+                        return el.parent && el.parent.classes.indexOf('figure') !== -1;
                     },
                     right: function(el) {
                         delete (el.styles['padding']);


### PR DESCRIPTION
fix issue where `el.parent.classes.indexOf('figure')` was returning -1, which was always making this true. explicitly check that figure doesn't exist with -1