### PR TITLE
allow the YouTube embed to be on the Newsroom since it was on the old News in the CMS

### DIFF
--- a/config.js
+++ b/config.js
@@ -181,7 +181,7 @@ CKEDITOR.editorConfig = function( config ) {
         ['Cut','Copy','Paste','PasteText','PasteFromWord','-','Undo','Redo'],
         ['Scayt'],
         ['Language','Link','Unlink','Anchor'],
-        ['Image','Table','HorizontalRule','SpecialChar'],
+        ['Image','Table','HorizontalRule','SpecialChar', 'Youtube'],
         ['Maximize'],
         ['Source'],
         '/',


### PR DESCRIPTION
YouTube embed used to be on the Add/Edit News area, but was removed on the Newsroom WYSIWYG, this brings it back to allow it to be embeddable.