### PR TITLE
fix: update `BulletedList` spelling to include the missing `e`

### DIFF
--- a/config.js
+++ b/config.js
@@ -220,6 +220,6 @@ CKEDITOR.editorConfig = function( config ) {
         ['About']
     ];
     config.toolbar_forms = [
-        ['Bold','Italic','Underline','-','Strike','-','JustifyLeft','JustifyCenter','JustifyRight','BulletdList','NumberedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', 'PasteText', 'RemoveFormat', 'Source'],
+        ['Bold','Italic','Underline','-','Strike','-','JustifyLeft','JustifyCenter','JustifyRight','BulletedList','NumberedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', 'PasteText', 'RemoveFormat', 'Source'],
     ];
 };


### PR DESCRIPTION
whoopsie