### PR TITLE
feat: add events toolbar and add separators to separate each area correctly

### DIFF
--- a/config.js
+++ b/config.js
@@ -225,6 +225,9 @@ CKEDITOR.editorConfig = function( config ) {
         ['About']
     ];
     config.toolbar_forms = [
-        ['Bold','Italic','Underline','-','Strike','-','JustifyLeft','JustifyCenter','JustifyRight','BulletedList','NumberedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', 'PasteText', 'RemoveFormat', 'Source'],
+        ['Bold','Italic','Underline', 'Strike','-','JustifyLeft','JustifyCenter','JustifyRight','BulletedList','NumberedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', '-', 'PasteText', 'RemoveFormat', 'Source'],
+    ];
+    config.toolbar_events = [
+        ['Bold','Italic','Underline', 'Strike','-','JustifyLeft','JustifyCenter','JustifyRight','BulletedList','NumberedList', 'Undo', 'Redo', 'Link', 'Unlink', 'Image', '-', 'PasteText', 'RemoveFormat', 'Source'],
     ];
 };


### PR DESCRIPTION
Before:
![SCR-20250527-jpza](https://github.com/user-attachments/assets/73ca21f4-94b1-4cdf-8c46-4d17f592ff23)

After:
![SCR-20250527-jpzz](https://github.com/user-attachments/assets/6a902254-457e-44c6-8a22-80a97bc7da8c)
