### PR TITLE
Feature | Allow span tags to be used with the ACF

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@ CKEDITOR.editorConfig = function( config ) {
     config.language_list = [ 'ar:Arabic:rtl', 'zh:Chinese', 'fr:French', 'de:German', 'id:Indonesian', 'it:Italian', 'ja:Japanese', 'ko:Korean', 'la:Latin', 'pt:Portuguese', 'es:Spanish', 'th:Thai', 'tr:Turkish', 'vi:Vietnamese'];
 
     // ACF rules not allowed by any plugins
-    config.extraAllowedContent = '*(*)[data-*,aria-*];' + // allow all classes and any data attribute on all elements
+    config.extraAllowedContent = '*(*)[data-*,aria-*];' + // allow all classes and any data or aria attribute on all elements
         'iframe{*}[width,height,src,allowfullscreen,title,allow,frameborder];' + // Don't require the attributes that the YouTube Plugin required
         'img{margin*,padding*}[usemap];' + // Allow margins and padding on <img> to be modifiable
         'blockquote cite;' + // Allow <cite> to be within the <blockquote>
@@ -29,7 +29,8 @@ CKEDITOR.editorConfig = function( config ) {
         'script(*)[*];' + // Allow script tags to be inserted
         'h1{line-height};h2{line-height};h3{line-height};h4{line-height};' + // Allow headers in the HTML editor to have line-heights
         'a[aria-label];' + // Allow aria-label on anchors
-        'map[id,name];area[shape,coords,href,alt];' // Allow map and area elements
+        'map[id,name];area[shape,coords,href,alt];' + // Allow map and area elements
+        'span;' // Allow span elements
     ;
 
     // Only allow specific link targets


### PR DESCRIPTION
Add the `<span>` tag as available in the ACF so CKEditor won't remove it.